### PR TITLE
Solve a tinny bug of pipeline parallelism

### DIFF
--- a/src/csrc/model/gpt/gpt.cc
+++ b/src/csrc/model/gpt/gpt.cc
@@ -560,6 +560,7 @@ std::vector<int64_t> Gpt<T>::forward(
 		sync_check_cuda_error();
 	}
 	else {
+		d_position_ids.remalloc(num_tokens);
 		if (parallelism_param.is_stage_leader()){
 			st::util::stNcclRecv(
 				d_decoder_input.ptr,

--- a/src/csrc/util/nccl_utils.cc
+++ b/src/csrc/util/nccl_utils.cc
@@ -1,4 +1,5 @@
 #include "nccl_utils.h"
+#include "util/cuda_utils.h"
 #include <cstdio>
 
 #define NCCL_CHECK(cmd)                                                                                           \
@@ -99,6 +100,7 @@ void stNcclRecv(
     }
 
     NCCL_CHECK(ncclRecv(buff, count, datatype, recv_from, comm.comm, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
 void stNcclSendRecv(


### PR DESCRIPTION
When using pipeline parallelism, the "d_position_ids" in stages other than the first stage will not be initialized, leading to memory access errors.
